### PR TITLE
Add endpoint to add items

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -5,10 +5,19 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+var items = []gin.H{
+	{"id": 1, "name": "Galactic Goggles"},
+	{"id": 2, "name": "Meteor Muffins"},
+	{"id": 3, "name": "Alien Antenna Kit"},
+	{"id": 4, "name": "Starlight Lantern"},
+	{"id": 5, "name": "Quantum Quill"},
+}
+
 func main() {
 	router := gin.Default()
 	router.GET("/", greet)
 	router.GET("/items", getItems)
+	router.POST("/items", addItem)
 	router.HEAD("/healthcheck", healthcheck)
 
 	router.Run()
@@ -25,12 +34,22 @@ func healthcheck(c *gin.Context) {
 }
 
 func getItems(c *gin.Context) {
-	items := []gin.H{
-		{"id": 1, "name": "Galactic Goggles"},
-		{"id": 2, "name": "Meteor Muffins"},
-		{"id": 3, "name": "Alien Antenna Kit"},
-		{"id": 4, "name": "Starlight Lantern"},
-		{"id": 5, "name": "Quantum Quill"},
-	}
 	c.JSON(http.StatusOK, items)
+}
+
+func addItem(c *gin.Context) {
+	var newItem struct {
+		Name string `json:"name" binding:"required"`
+	}
+
+	if err := c.ShouldBindJSON(&newItem); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id := len(items) + 1
+	item := gin.H{"id": id, "name": newItem.Name}
+	items = append(items, item)
+
+	c.JSON(http.StatusOK, item)
 }


### PR DESCRIPTION
This pull request adds a new endpoint to the backend code that allows users to add items to the existing list of items. The new endpoint is implemented in the `main.go` file and accepts a JSON payload with the name of the item to be added. If the payload is valid, the item is added to the list of items and a JSON response with the newly added item is returned. If the payload is invalid, a JSON response with an error message is returned.